### PR TITLE
Fix Favorite propTypes

### DIFF
--- a/client/src/components/Favorite.js
+++ b/client/src/components/Favorite.js
@@ -21,8 +21,7 @@ const Favorite = ({
 
 Favorite.propTypes = {
   selected: PropTypes.bool,
-  addToFavorites: PropTypes.func,
-  selected: PropTypes.func,
+  addToFavorites: PropTypes.func
 }
 
 /**


### PR DESCRIPTION
This change fixes the following `PropType` warning

![image](https://user-images.githubusercontent.com/2852660/37254463-19735a92-2536-11e8-89e9-bb8df828a1bb.png)
